### PR TITLE
additional code to add/remove child view controllers

### DIFF
--- a/GBRetractableTabBar.podspec
+++ b/GBRetractableTabBar.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "GBRetractableTabBar"
-  s.version      = "1.2.0"
+  s.version      = "1.3.0"
   s.summary      = "iOS Control for a retractable tab bar that supports full customisation in terms of sizing, behaviour, and custom views."
   s.homepage     = "https://github.com/lmirosevic/GBRetractableTabBar"
   s.license      = 'Apache License, Version 2.0'

--- a/GBRetractableTabBar/GBRetractableTabBar.m
+++ b/GBRetractableTabBar/GBRetractableTabBar.m
@@ -440,15 +440,21 @@ _lazy(NSMutableArray, myViewControllers, _myViewControllers)
 
 -(void)_hideViewController:(UIViewController *)viewController {
     if (viewController) {
+        [viewController willMoveToParentViewController:nil];
         [viewController.view removeFromSuperview];
+        [viewController removeFromParentViewController];
     }
 }
 
 -(void)_showViewController:(UIViewController *)viewController {
     if (viewController) {
+        [self addChildViewController:viewController];
+        
         viewController.view.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
         viewController.view.frame = self.contentView.bounds;
         [self.contentView addSubview:viewController.view];
+        
+        [viewController didMoveToParentViewController:self];
     }
 }
 


### PR DESCRIPTION
We need to call those methods when showing/hiding UIViewControllers otherwise they won't be on a view hierarchy.

Another solution could be to add them at *-addViewController:withControlView:* but I think this approach is a little cleaner.